### PR TITLE
Replace manual quiet mode with quiet parameter

### DIFF
--- a/ap_preserve_header/preserve_headers.py
+++ b/ap_preserve_header/preserve_headers.py
@@ -385,12 +385,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Configure logging using ap-common's setup_logging
-    # --quiet takes precedence over --debug
-    if args.quiet:
-        setup_logging(name=__name__, debug=False)
-        logging.getLogger(__name__).setLevel(logging.WARNING)
-    else:
-        setup_logging(name=__name__, debug=args.debug)
+    setup_logging(name=__name__, debug=args.debug, quiet=args.quiet)
 
     preserve_headers(
         root_dir=args.root_dir,

--- a/tests/test_preserve_headers.py
+++ b/tests/test_preserve_headers.py
@@ -472,9 +472,8 @@ class TestMain:
             dryrun=False,
         )
         mock_setup_logging.assert_called_once_with(
-            name="ap_preserve_header.preserve_headers", debug=False
+            name="ap_preserve_header.preserve_headers", debug=False, quiet=True
         )
-        mock_logger.setLevel.assert_called_once_with(logging.WARNING)
 
     @patch("ap_preserve_header.preserve_headers.preserve_headers")
     @patch("ap_preserve_header.preserve_headers.setup_logging")
@@ -498,9 +497,8 @@ class TestMain:
             dryrun=False,
         )
         mock_setup_logging.assert_called_once_with(
-            name="ap_preserve_header.preserve_headers", debug=False
+            name="ap_preserve_header.preserve_headers", debug=False, quiet=True
         )
-        mock_logger.setLevel.assert_called_once_with(logging.WARNING)
 
     @patch("ap_preserve_header.preserve_headers.preserve_headers")
     @patch("ap_preserve_header.preserve_headers.setup_logging")
@@ -532,9 +530,8 @@ class TestMain:
             include_headers=["CAMERA"],
             dryrun=False,
         )
-        # --quiet should take precedence, so setup_logging is called with debug=False
-        # and logger level is set to WARNING
+        # --debug takes precedence over --quiet in the new implementation
+        # Both flags are passed to setup_logging, which will use DEBUG level
         mock_setup_logging.assert_called_once_with(
-            name="ap_preserve_header.preserve_headers", debug=False
+            name="ap_preserve_header.preserve_headers", debug=True, quiet=True
         )
-        mock_logger.setLevel.assert_called_once_with(logging.WARNING)


### PR DESCRIPTION
Replace manual quiet mode implementation with new quiet parameter in setup_logging(). The new implementation uses debug-takes-precedence behavior (debug=True overrides quiet=True).

Changes:
- Replace manual if/else quiet mode logic with single setup_logging() call
- Pass quiet=args.quiet parameter to setup_logging()
- Update tests to expect quiet parameter and debug-precedence behavior
- Remove manual logger.setLevel() calls (handled by setup_logging)

All 33 tests pass.

Addresses ap-base plan: Quiet Mode Support (Phase 3)

Assisted-by: Claude Code (Claude Sonnet 4.5)